### PR TITLE
feat(about): refresh AI/ML positioning and profile copy

### DIFF
--- a/content/pages/about/index.mdx
+++ b/content/pages/about/index.mdx
@@ -3,80 +3,82 @@ title: About
 slug: '/about'
 ---
 
-I've spent 13 years building software since graduating with a B.S. in Software Engineering in 2013, working across full-stack engineering, solution architecture, and entrepreneurship.
+I work across product engineering, solution architecture, and startup building. Since graduating with a B.S. in Software Engineering in 2013, I've worked on e-commerce, fintech, compliance, trading platforms, and developer tooling.
 
-I later completed an M.S. in Computer Science focused on Artificial Intelligence, and today I work at the intersection of cloud native architecture, microservices/serverless, and AI/ML.
+I later completed an M.S. in Computer Science focused on Artificial Intelligence. These days I'm most interested in cloud native systems, microservices/serverless, and applied AI/ML.
 
-#### Full Stack Skill-set
+#### Core skill set
 
-- **Frontend**: React (Next.js), Styled Components, Tailwind CSS, Progressive Web App, Atomic Design.
-- **Backend**: Node.js (NestJS), WebSocket, GraphQL, RESTful, Kafka, PostgreSQL, MongoDB, Redis.
-- **DevOps**: Bash, Docker, Kubernetes, Terraform, Argo, Emissary-Ingress, Istio, OpenTelemetry, SigNoz, AWS.
-- **AI/ML**: Applied AI/ML, LLM application development, model evaluation, Hugging Face, and MLOps.
+- **Frontend**: React (Next.js), Styled Components, Tailwind CSS, PWAs, Atomic Design.
+- **Backend**: Node.js (NestJS), WebSocket, GraphQL, REST APIs, Kafka, PostgreSQL, MongoDB, Redis.
+- **Platform/DevOps**: Docker, Kubernetes, Terraform, Argo, Emissary-Ingress, Istio, OpenTelemetry, SigNoz, AWS, Bash.
+- **AI/ML**: PyTorch, PyTorch Geometric, Transformers, PEFT/LoRA fine-tuning, Optuna, Hydra, Weights & Biases, DVC, and Hugging Face.
 - **Tools**: TypeScript, Jest, Testing Library, ESLint, Prettier, Webpack, VS Code.
 
 #### Experience
 
+Some founder roles below overlapped with full-time positions while I was building products and client systems.
+
 - **Aug 2021 to Jan 2025**: Team Lead at [Setel](https://setel.com)
 
-  Leading a team of 10 Mobile, Full stack & Automation QC engineers to build eKYC, fraud & compliance control for Setel ecosystem using React, Node.js, Kubernetes & AWS.
+  Led a team of 10 mobile, full-stack, and QA automation engineers to build eKYC, fraud detection, and compliance systems for the Setel ecosystem using React, Node.js, Kubernetes, and AWS.
 
-  Successfully launched eKYC for Setel Wallet & ensured Setel products are in compliance with PDPA & GDPR.
+  Launched eKYC for Setel Wallet and helped keep Setel products aligned with PDPA and GDPR requirements.
 
 - **Oct 2020 to Aug 2021**: Solutions Architect at [FPT Software](https://www.fpt-software.com)
 
-  Led a 7-member team to build a web-based system for a FinTech enterprise in Europe. Joined in many POC projects as a proposal to companies in the US & Canada. The techstack was React, Node.js, Kubernetes, Serverless & AWS.
+  Led a 7-member team to build a web-based system for a fintech enterprise in Europe. Worked on several POCs for prospective clients in the US and Canada using React, Node.js, Kubernetes, serverless, and AWS.
 
-  Worked as Architect in 2 POC projects that helped the business unit to get 2 contracts from the USA.
+  Served as architect on two POC projects that helped the business unit secure two US contracts.
 
 - **Nov 2018 to Oct 2020**: Co-founder & CTO at a startup.
 
-  So-lo built a performance & scalable web-based trading platform based on React, Node.js, Kafka, PostgreSQL, MongoDB, Redis & Kubernetes.
+  Built the core of a scalable web-based trading platform using React, Node.js, Kafka, PostgreSQL, MongoDB, Redis, and Kubernetes.
 
-  No accomplishment so far because the co-founder quitted before launching.
+  Built the product and platform architecture, but the company did not launch after the co-founder left.
 
 - **Mar 2018 to Nov 2018**: Tech Lead at [Leflair Vietnam](https://leflair.vn)
 
-  Got promoted after the CTO left. Built up the team of 10 to develop the new version of the [leflair.vn](https://leflair.vn) website using Next.js, and migrate the backend from Monolithic to Microservices architecture using Node.js, MongoDB, Kubernetes & Google Cloud.
+  Promoted after the CTO left. Built a team of 10 to develop the new version of the [leflair.vn](https://leflair.vn) website using Next.js, and migrated the backend from a monolith to microservices using Node.js, MongoDB, Kubernetes, and Google Cloud.
 
-  The website served 500k customers & millions of monthly traffic with a 4-nine availability (99.99% uptime).
+  The platform served 500k customers and millions of monthly visits with 99.99% uptime.
 
 - **Nov 2016 to Mar 2018**: Full Stack Developer at [Leflair Vietnam](https://leflair.vn)
 
-  Built the e-commerce website leflair.vn from scratch using MERN stack (MongoDB, Express, React & Node.js).
+  Built the e-commerce website leflair.vn from scratch using the MERN stack (MongoDB, Express, React, and Node.js).
 
-  The website went live in production successfully after 3 months of being a React newbie. The website performance increased significantly compared to the previous AngularJS version.
+  The site went live after three months and significantly improved performance over the previous AngularJS version.
 
 - **2015 to 2018**: Founder & CTO at [Gorillab](https://github.com/gorillab)
 
-  Led the 4-freelancers team to build several web & mobile-based apps for clients in Vietnam, Singapore & the US using MERN stack (MongoDB, Express, React & Node.js).
+  Led a four-person freelance team to build web and mobile apps for clients in Vietnam, Singapore, and the US using the MERN stack (MongoDB, Express, React, and Node.js).
 
-  One of the products is an Order Management System built for the client in the US which had been operating for years without a problem.
+  One product, an order management system for a US client, ran reliably in production for years.
 
 - **2015 to 2017**: Co-founder & CTO at Fugu Inc.
 
-  So-lo built a Point-of-Sale as a Service for local coffee shops & restaurants based on MEAN stack (MongoDB, Express, AngularJS & Node.js).
+  Built the point-of-sale-as-a-service product independently for local coffee shops and restaurants using the MEAN stack (MongoDB, Express, AngularJS, and Node.js).
 
-  The service was used at 3 Japanese restaurants in Ho Chi Minh & Ha Noi for 2 years.
+  The service was used by three Japanese restaurants in Ho Chi Minh City and Hanoi for two years.
 
 - **2013 to 2015**: PHP Developer Lead at [Softfoundry](http://www.softfoundry.com)
 
-  Led a small team to develop several web-based products such as video conference (VMeet), video portal, e-commerce, e-learning, etc...
+  Led a small team to build products including VMeet, a video portal, e-commerce systems, and e-learning platforms.
 
-  VMeet was used by the GOVs of Thailand, Vietnam & other SEA countries.
+  VMeet was used by the governments of Thailand, Vietnam, and other SEA countries.
 
 #### Education
 
-- **2024 to 2026**: Graduated M.S. in Computer Science, major in Artificial Intelligence at [Sai Gon University](http://sgu.edu.vn/) Vietnam.
+- **2024 to 2026**: Graduated M.S. in Computer Science, focused on Artificial Intelligence at [Sai Gon University](http://sgu.edu.vn/) Vietnam.
 - **2009 to 2013**: Graduated B.S. in Software Engineering at [Van Lang University](http://www.vanlanguni.edu.vn/) Vietnam whose program was transferred from [Carnegie Mellon University](https://cmu.edu) USA.
 
 #### Open Source Projects
 
-- Explore my open source projects on GitHub [/phatpham9](https://github.com/phatpham9), [/boringcode-dev](https://github.com/boringcode-dev).
+- I publish developer tools and experiments on GitHub [/phatpham9](https://github.com/phatpham9) and [/boringcode-dev](https://github.com/boringcode-dev).
 
 #### AI/ML Contributions
 
-- Explore my AI/ML experiments on Hugging Face [/phatpham9](https://huggingface.co/phatpham9).
+- I share AI/ML experiments on Hugging Face [/phatpham9](https://huggingface.co/phatpham9), with a focus on biomedical NLP, graph learning, and model evaluation.
 
 #### Daily Tech Reads
 

--- a/content/pages/about/index.mdx
+++ b/content/pages/about/index.mdx
@@ -12,8 +12,7 @@ I later completed an M.S. in Computer Science focused on Artificial Intelligence
 - **Frontend**: React (Next.js), Styled Components, Tailwind CSS, PWAs, Atomic Design.
 - **Backend**: Node.js (NestJS), WebSocket, GraphQL, REST APIs, Kafka, PostgreSQL, MongoDB, Redis.
 - **Platform/DevOps**: Docker, Kubernetes, Terraform, Argo, Emissary-Ingress, Istio, OpenTelemetry, SigNoz, AWS, Bash.
-- **AI/ML**: PyTorch, PyTorch Geometric, Transformers, PEFT/LoRA fine-tuning, Optuna, Hydra, Weights & Biases, DVC, and Hugging Face.
-- **Tools**: TypeScript, Jest, Testing Library, ESLint, Prettier, Webpack, VS Code.
+- **AI/ML**: PyTorch, Transformers, PEFT/LoRA, Optuna, Hydra, Weights & Biases, DVC, Hugging Face.
 
 #### Experience
 
@@ -29,13 +28,13 @@ Some founder roles below overlapped with full-time positions while I was buildin
 
   Led a 7-member team to build a web-based system for a fintech enterprise in Europe. Worked on several POCs for prospective clients in the US and Canada using React, Node.js, Kubernetes, serverless, and AWS.
 
-  Served as architect on two POC projects that helped the business unit secure two US contracts.
+  Served as architect on POC projects that helped the business unit secure US contracts.
 
 - **Nov 2018 to Oct 2020**: Co-founder & CTO at a startup.
 
   Built the core of a scalable web-based trading platform using React, Node.js, Kafka, PostgreSQL, MongoDB, Redis, and Kubernetes.
 
-  Built the product and platform architecture, but the company did not launch after the co-founder left.
+  Built the product and platform architecture, but the project was shut down before launch.
 
 - **Mar 2018 to Nov 2018**: Tech Lead at [Leflair Vietnam](https://leflair.vn)
 
@@ -74,11 +73,7 @@ Some founder roles below overlapped with full-time positions while I was buildin
 
 #### Open Source Projects
 
-- I publish developer tools and experiments on GitHub [/phatpham9](https://github.com/phatpham9) and [/boringcode-dev](https://github.com/boringcode-dev).
-
-#### AI/ML Contributions
-
-- I share AI/ML experiments on Hugging Face [/phatpham9](https://huggingface.co/phatpham9), with a focus on biomedical NLP, graph learning, and model evaluation.
+- I publish developer tools and AI/ML experiments on GitHub [/phatpham9](https://github.com/phatpham9), [/boringcode-dev](https://github.com/boringcode-dev), and Hugging Face [/phatpham9](https://huggingface.co/phatpham9).
 
 #### Daily Tech Reads
 

--- a/content/pages/about/index.mdx
+++ b/content/pages/about/index.mdx
@@ -3,11 +3,16 @@ title: About
 slug: '/about'
 ---
 
+I've spent 13 years building software since graduating with a B.S. in Software Engineering in 2013, working across full-stack engineering, solution architecture, and entrepreneurship.
+
+I later completed an M.S. in Computer Science focused on Artificial Intelligence, and today I work at the intersection of cloud native architecture, microservices/serverless, and AI/ML.
+
 #### Full Stack Skill-set
 
 - **Frontend**: React (Next.js), Styled Components, Tailwind CSS, Progressive Web App, Atomic Design.
 - **Backend**: Node.js (NestJS), WebSocket, GraphQL, RESTful, Kafka, PostgreSQL, MongoDB, Redis.
 - **DevOps**: Bash, Docker, Kubernetes, Terraform, Argo, Emissary-Ingress, Istio, OpenTelemetry, SigNoz, AWS.
+- **AI/ML**: Applied AI/ML, LLM application development, model evaluation, Hugging Face, and MLOps.
 - **Tools**: TypeScript, Jest, Testing Library, ESLint, Prettier, Webpack, VS Code.
 
 #### Experience

--- a/src/@lekoarts/gatsby-theme-minimal-blog/texts/hero.mdx
+++ b/src/@lekoarts/gatsby-theme-minimal-blog/texts/hero.mdx
@@ -1,7 +1,7 @@
 <h2 style="margin-bottom: 4rem;">Hi there, I'm Phat Pham 👋</h2>
 
-I've spent 13 years building software since graduating with a B.S. in Software Engineering in 2013, working as a full-stack developer, solution architect, and entrepreneur.
+I've spent 13 years building software as a full-stack developer, solution architect, and entrepreneur, taking products from early ideas to production.
 
-I later completed an M.S. in Computer Science, and along the way I've founded two startups. My current interests sit at the intersection of cloud native architecture, microservices/serverless, and AI/ML.
+My background is in Software Engineering and Computer Science, and along the way I've founded two startups. My current interests sit at the intersection of cloud native architecture, microservices/serverless, and AI/ML.
 
 You can find my work on GitHub [/phatpham9](https://github.com/phatpham9), [/boringcode-dev](https://github.com/boringcode-dev) and Hugging Face [/phatpham9](https://huggingface.co/phatpham9).

--- a/src/@lekoarts/gatsby-theme-minimal-blog/texts/hero.mdx
+++ b/src/@lekoarts/gatsby-theme-minimal-blog/texts/hero.mdx
@@ -1,7 +1,7 @@
 <h2 style="margin-bottom: 4rem;">Hi there, I'm Phat Pham 👋</h2>
 
-I've spent 13 years building software as a full-stack developer, solution architect, and entrepreneur, taking products from early ideas to production.
+I've spent 13 years building software since graduating with a B.S. in Software Engineering in 2013, working as a full-stack developer, solution architect, and entrepreneur.
 
-My background is in Software Engineering and Computer Science, and along the way I've founded two startups. My current interests sit at the intersection of cloud native architecture, microservices/serverless, and AI/ML.
+I later completed an M.S. in Computer Science, and along the way I've founded two startups. My current interests sit at the intersection of cloud native architecture, microservices/serverless, and AI/ML.
 
 You can find my work on GitHub [/phatpham9](https://github.com/phatpham9), [/boringcode-dev](https://github.com/boringcode-dev) and Hugging Face [/phatpham9](https://huggingface.co/phatpham9).


### PR DESCRIPTION
## Summary
- rewrite the About page intro to better reflect product engineering, architecture, startup, and AI/ML positioning
- replace the old generic skill section with a clearer core skill set, including the updated AI/ML stack
- tighten the experience bullets for clarity and remove unnecessary specifics around contract counts and shutdown reasons
- update the education copy and consolidate the open source / AI-ML profile links into a single Open Source Projects section

## Files changed
- `content/pages/about/index.mdx`

## Review focus
- wording and tone of the About page
- AI/ML stack accuracy
- work history phrasing and level of detail
- final section structure for Open Source Projects
